### PR TITLE
AppiumTimeCapabilities datatype fix

### DIFF
--- a/src/main/java/com/testvagrant/ekam/mobile/AppiumTimeCapabilities.java
+++ b/src/main/java/com/testvagrant/ekam/mobile/AppiumTimeCapabilities.java
@@ -1,0 +1,17 @@
+package com.testvagrant.ekam.mobile;
+
+public enum AppiumTimeCapabilities {
+    newCommandTimeout,
+    appWaitDuration,
+    deviceReadyTimeout,
+    androidDeviceReadyTimeout,
+    androidInstallTimeout,
+    avdLaunchTimeout,
+    avdReadyTimeout,
+    autoWebviewTimeout,
+    adbExecTimeout,
+    launchTimeout,
+    interKeyDelay,
+    screenshotWaitTimeout,
+    webkitResponseTimeout;
+}

--- a/src/main/java/com/testvagrant/ekam/mobile/models/MobileTestFeed.java
+++ b/src/main/java/com/testvagrant/ekam/mobile/models/MobileTestFeed.java
@@ -1,12 +1,10 @@
 package com.testvagrant.ekam.mobile.models;
 
+import com.testvagrant.ekam.mobile.AppiumTimeCapabilities;
 import com.testvagrant.ekam.commons.parsers.SystemPropertyParser;
 import lombok.*;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Getter
 @Setter
@@ -25,8 +23,15 @@ public class MobileTestFeed {
       };
     public Map<String,Object> parseSystemProperty(Map<String,Object>capabilities){
         Map<String,Object>parsedCapabilities=new HashMap<>();
-        for(Map.Entry<String,Object>property:capabilities.entrySet())
-            parsedCapabilities.put(property.getKey(), SystemPropertyParser.parse(property.getValue().toString()));
+        for(Map.Entry<String,Object>property:capabilities.entrySet()) {
+            String capability=property.getKey();
+            String capabilityValue=SystemPropertyParser.parse(property.getValue().toString().trim());
+            if(Arrays.stream(AppiumTimeCapabilities.values()).anyMatch((t) -> t.name().equals(capability))) {
+                parsedCapabilities.put(capability, Double.valueOf(capabilityValue).intValue());
+                continue;
+            }
+            parsedCapabilities.put(capability,capabilityValue);
+        }
         return parsedCapabilities;
     }
 

--- a/src/test/java/com/testvagrant/ekam/mobile/MobileConfigParserTests.java
+++ b/src/test/java/com/testvagrant/ekam/mobile/MobileConfigParserTests.java
@@ -120,6 +120,17 @@ public class MobileConfigParserTests {
     Assertions.assertEquals("", desiredCapabilities.getCapability("app"));
   }
 
+  @Test
+  @SetSystemProperty(key = "mobile.feed", value = "env_mobile_feed")
+  @SetSystemProperty(key = "app", value = "bs://blahhh.com")
+  @SetSystemProperty(key="automationName",value="UiAutomator2")
+  public void shouldConsiderTheIntegerTypeInDesiredCapabilities(){
+    Injector injector=Guice.createInjector(new EkamConfigModule());
+    EkamConfig ekamConfig=injector.getInstance(EkamConfig.class);
+    MobileConfigParser mobileConfigParser=new MobileConfigParser(ekamConfig.getMobile());
+    DesiredCapabilities desiredCapabilities=mobileConfigParser.getDesiredCapabilities();
+    Assertions.assertEquals(desiredCapabilities.getCapability("newCommandTimeout").getClass(), Integer.class);
+  }
   private List<TargetDetails> getTargetDetails() {
     TargetDetails iosEmulator =
         TargetDetails.builder()

--- a/src/test/resources/mobile/env_mobile_feed.json
+++ b/src/test/resources/mobile/env_mobile_feed.json
@@ -4,7 +4,8 @@
       "app": "${env:app}",
       "appWaitActivity": "com.swaglabsmobileapp.MainActivity",
       "platformName": "android",
-      "automationName": "${env:automationName}"
+      "automationName": "${env:automationName}",
+      "newCommandTimeout": 300
     }
   ]
 }


### PR DESCRIPTION
* Changed logic in MobileTestFeed to handle the datatype
* Added new command timeout property in desired capabilities
* enum Class for AppiumTimeCapabilities